### PR TITLE
feat(build.yml): invalidate cloudfront

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build njcode-webpage and deploy on AWS EB
 
-on: [ push ]
+on:
+ push:
+   branches: [ main ]
 
 env:
   # AWS


### PR DESCRIPTION
We should invalidate cloudfront cache on every push to main in order to offer our most recent release.